### PR TITLE
fix: changed comments author from User to PublicUser

### DIFF
--- a/components/shared/recipe/RecipeComment.tsx
+++ b/components/shared/recipe/RecipeComment.tsx
@@ -1,19 +1,20 @@
 import { VStack, Text } from "@chakra-ui/react";
-import { User } from "types/User";
+import { PublicUser } from "types/User";
 import CommentAuthor from "./CommentAuthor";
 
 type RecipeCommentProps = {
-  author: User | undefined;
+  author: PublicUser | undefined;
   content: string | undefined;
   date: number | undefined;
   rating: number | undefined;
 };
 
-const RecipeComment = ({ author, date, content, rating }: RecipeCommentProps) => {
-  const name = `${author?.info?.firstname || ""} ${
-    author?.info?.lastname || ""
-  }`.trim();
-
+const RecipeComment = ({
+  author,
+  date,
+  content,
+  rating,
+}: RecipeCommentProps) => {
   const avatar = author?.id
     ? `${process.env.NEXT_PUBLIC_CODIGA_API}/user/${author.id}/avatar`
     : "";
@@ -22,7 +23,7 @@ const RecipeComment = ({ author, date, content, rating }: RecipeCommentProps) =>
     <VStack w="100%" spacing={4} alignItems="flex-start">
       <CommentAuthor
         avatar={avatar}
-        name={author?.username || name || "Anonymous User"}
+        name={author?.displayName || "Anonymous User"}
         date={date ? new Date(date)?.toLocaleString() : ""}
         rating={rating || 0}
       />

--- a/queries/recipes.ts
+++ b/queries/recipes.ts
@@ -48,12 +48,9 @@ export const GET_PUBLIC_RECIPE_BY_ID = gql`
         comment
         author {
           id
-          username
-          info {
-            firstname
-            lastname
-            url
-          }
+          hasSlug
+          slug
+          displayName
         }
       }
       commentsCount

--- a/types/Comment.ts
+++ b/types/Comment.ts
@@ -1,4 +1,4 @@
-import { User } from "./User";
+import { PublicUser } from "./User";
 
 export type Comment = {
   id?: number;
@@ -6,5 +6,5 @@ export type Comment = {
   rating?: number;
   comment?: string;
   securityFlag?: boolean;
-  author?: User;
+  author?: PublicUser;
 };

--- a/types/User.ts
+++ b/types/User.ts
@@ -8,3 +8,10 @@ export type User = {
   username?: string;
   info?: UserInfo;
 };
+
+export type PublicUser = {
+  id?: number;
+  hasSlug?: boolean;
+  slug?: string;
+  displayName?: string;
+};


### PR DESCRIPTION
Fix for pages crashing due to invalid query structure.

I updated the comments author field to `PublicUser` instead of `User`.